### PR TITLE
Updated herbie requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     django >= 3.0, < 4.0
     djangorestframework >= 3.11,  < 4.0
     google-cloud-pubsub >= 1.5.0, < 2.0
-    herbie == 1.0b1
+    herbie >= 1.0b1
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Does it have to be binded to versions 1.01b? Since now the newer version of the Herbie has changed, the adapters packages are breaking.